### PR TITLE
What should be set is `DEBUG_SYSLOG` instead of `SYSLOG_DEBUG`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Change log level, set to 'info' for default.
 i.e. https://ACCESS_TOKEN@my-server/logs/:source/:env
 
 
-### ```SYSLOG_DEBUG```
+### ```DEBUG_SYSLOG```
 
 
 (optional) set to "true" to be able to debug received syslog messages, inspect result with


### PR DESCRIPTION
See https://github.com/dsaradini/heroku-influxdb-drain/search?utf8=%E2%9C%93&q=debug_syslog&type=