### PR TITLE
`error` is already a tag so it's redundant to also have it as a field

### DIFF
--- a/src/syslog_drain.js
+++ b/src/syslog_drain.js
@@ -240,8 +240,7 @@ function handle_heroku_errors(message, tags) {
                 error: result
             }, tags),
             fields: {
-                count: 1,
-                error: result
+                count: 1
             }
         }
     ]

--- a/test/test_syslog_drain.js
+++ b/test/test_syslog_drain.js
@@ -178,8 +178,7 @@ describe('Syslog drain server', function () {
                 });
                 assert.deepEqual(p0.timestamp, new Date("2017-08-31T14:47:14.000Z"));
                 assert.deepEqual(p0.fields, {
-                    count: 1,
-                    error: 'L10'
+                    count: 1
                 });
 
                 const p1 = influx_points[1];
@@ -212,8 +211,7 @@ describe('Syslog drain server', function () {
                 });
                 assert.deepEqual(p0.timestamp, new Date("2018-03-29T14:18:26.133Z"));
                 assert.deepEqual(p0.fields, {
-                    count: 1,
-                    error: 'H10'
+                    count: 1
                 });
             });
     });


### PR DESCRIPTION
Why keep it as tag rather than as a field? Well, in InfluxDB fields are
generally used for "measurements". Think size, duration, rate, etc. And tags
are something that you expect to be grouping by at some stage. I.e. "show me
how many errors occurred last week, grouped by error type".