### PR TITLE
`release` should be a tag rather than a field

### DIFF
--- a/src/syslog_drain.js
+++ b/src/syslog_drain.js
@@ -192,6 +192,7 @@ function handle_heroku_release(message, tags) {
         return [];
     }
     const all_tags = Object.assign({
+        version: result[0],
         user: result[1]
     }, tags);
     return [
@@ -199,10 +200,7 @@ function handle_heroku_release(message, tags) {
             timestamp: message.time,
             name: "heroku_release",
             tags: all_tags,
-            value: 1,
-            fields: {
-                version: result[0]
-            }
+            value: 1
         }
     ]
 }

--- a/test/test_parse_content.js
+++ b/test/test_parse_content.js
@@ -71,10 +71,10 @@ describe('Heroku log parser', function() {
                     "pid": "api",
                     "process": "api",
                     "source": "test-source",
-                    "user": "david.saradini@me.com"
+                    "user": "david.saradini@me.com",
+                    "version": "v48"
                 });
                 assert.deepEqual(points[0].value, 1);
-                assert.deepEqual(points[0].fields.version, "v48");
             })
     });
 

--- a/test/test_syslog_drain.js
+++ b/test/test_syslog_drain.js
@@ -161,6 +161,7 @@ describe('Syslog drain server', function () {
                 });
             })
     });
+
     it("should generate errors from heroku dyno", () => {
         const message = `142 <172>1 2017-08-31T14:47:14+00:00 host heroku logplex - Error L10 (output buffer overflow): 2 messages dropped since 2017-08-31T14:44:12+00:00.203 <45>1 2017-08-31T14:47:13.830178+00:00 host heroku web.1 - source=web.1 dyno=heroku.55681600.b0bc8784-5574-4f35-9508-5ea02d47d251 sample#load_avg_1m=0.00 sample#load_avg_5m=0.00 sample#load_avg_15m=0.00
 334 <45>1 2017-08-31T14:47:13.830269+00:00 host heroku web.1 - source=web.1 dyno=heroku.55681600.b0bc8784-5574-4f35-9508-5ea02d47d251 sample#memory_total=201.71MB sample#memory_rss=190.07MB sample#memory_cache=0.33MB sample#memory_swap=11.30MB sample#memory_pgpgin=88604pages sample#memory_pgpgout=53146pages sample#memory_quota=512.00MB`;


### PR DESCRIPTION
In InfluxDB, fields are generally used for "measurements". Think size, duration, rate, etc. And tags are something that you expect to be grouping by at some stage. I.e. "show me how many errors occurred last week, grouped by error type".

While the value of `release` (ever increasing integer) implies it should be a field, in fact, it should be a tag. Especially when draining logs from multiple apps, you want to be able to construct (continuous) queries that group by release version. Hence, `release` needs to be a tag, not a field.