### PR TITLE
A bit of refactor

### DIFF
--- a/src/syslog_drain.js
+++ b/src/syslog_drain.js
@@ -107,12 +107,12 @@ exports.parse_heroku_state_changed = parse_heroku_state_changed;
  * @returns error code
  */
 function parse_heroku_errors(value) {
-    var releaseRegexp = new RegExp(`^Error (L|R)([0-9]{2,})`);
-    var match = releaseRegexp.exec(value);
+    var errorRegexp = new RegExp(`^Error (L|R)([0-9]{2,})`);
+    var match = errorRegexp.exec(value);
 
     if (!match) {
-        releaseRegexp = new RegExp(`^at=error code=(H)([0-9]{2,})`);
-        match = releaseRegexp.exec(value);
+        errorRegexp = new RegExp(`^at=error code=(H)([0-9]{2,})`);
+        match = errorRegexp.exec(value);
     }
 
     if (!match) {

--- a/src/syslog_drain.js
+++ b/src/syslog_drain.js
@@ -191,15 +191,14 @@ function handle_heroku_release(message, tags) {
     if (!result) {
         return [];
     }
-    const all_tags = Object.assign({
-        version: result[0],
-        user: result[1]
-    }, tags);
     return [
         {
             timestamp: message.time,
             name: "heroku_release",
-            tags: all_tags,
+            tags: Object.assign({
+                version: result[0],
+                user: result[1]
+            }, tags),
             value: 1
         }
     ]
@@ -237,9 +236,7 @@ function handle_heroku_errors(message, tags) {
             tags: Object.assign({
                 error: result
             }, tags),
-            fields: {
-                count: 1
-            }
+            value: 1
         }
     ]
 }

--- a/test/test_syslog_drain.js
+++ b/test/test_syslog_drain.js
@@ -179,7 +179,7 @@ describe('Syslog drain server', function () {
                 });
                 assert.deepEqual(p0.timestamp, new Date("2017-08-31T14:47:14.000Z"));
                 assert.deepEqual(p0.fields, {
-                    count: 1
+                    value: 1
                 });
 
                 const p1 = influx_points[1];
@@ -212,7 +212,7 @@ describe('Syslog drain server', function () {
                 });
                 assert.deepEqual(p0.timestamp, new Date("2018-03-29T14:18:26.133Z"));
                 assert.deepEqual(p0.fields, {
-                    count: 1
+                    value: 1
                 });
             });
     });


### PR DESCRIPTION
Making code more consistent. 

Note that `heroku_error` measurement now has `value: 1` instead of `count: 1`, which makes it consistent with `heroku_release` and `heroku_state` which both use `value` instead of `count`.